### PR TITLE
Handle empty vscode settings

### DIFF
--- a/puro/lib/src/workspace/vscode.dart
+++ b/puro/lib/src/workspace/vscode.dart
@@ -30,8 +30,9 @@ class VSCodeConfig extends IdeConfig {
         indentLevel: 4,
       );
     }
+    final source = settingsFile.readAsStringSync();
     return JsonEditor(
-      source: settingsFile.readAsStringSync(),
+      source: source.isEmpty ? '{}' : source,
       indentLevel: 4,
     );
   }

--- a/puro/test/json_edit_test.dart
+++ b/puro/test/json_edit_test.dart
@@ -147,19 +147,6 @@ void main() {
     );
   });
 
-  test('Test empty settings file in .vscode', () {
-    testUpdate(
-      '',
-      ['a'],
-      {'b': 'c'},
-      '''{
-          "a": {
-            "b": "c"
-          }
-        }''',
-    );
-  });
-
   test('Dont expand map single-line siblings', () {
     testUpdate(
       '{"x": "y"}',

--- a/puro/test/json_edit_test.dart
+++ b/puro/test/json_edit_test.dart
@@ -147,6 +147,19 @@ void main() {
     );
   });
 
+  test('Test empty settings file in .vscode', () {
+    testUpdate(
+      '',
+      ['a'],
+      {'b': 'c'},
+      '''{
+          "a": {
+            "b": "c"
+          }
+        }''',
+    );
+  });
+
   test('Dont expand map single-line siblings', () {
     testUpdate(
       '{"x": "y"}',


### PR DESCRIPTION
I was getting an error while running `puro use <env>` and I figured out that the reason was the settings.json was empty.  