### PR TITLE
Capture SIGINT and SIGTERM so that the Dart process behaves correctly

### DIFF
--- a/puro/lib/src/env/command.dart
+++ b/puro/lib/src/env/command.dart
@@ -171,8 +171,7 @@ Future<int> runDartCommand({
 Future<void> Function() _setupExitSignals(ProcessStartMode mode) {
   StreamSubscription<ProcessSignal>? sigIntSub, sigTermSub;
 
-  if (mode == ProcessStartMode.normal ||
-      mode == ProcessStartMode.inheritStdio) {
+  if (mode == ProcessStartMode.inheritStdio) {
     sigIntSub = ProcessSignal.sigint.watch().listen((_) {});
 
     // SIGTERM is not supported on Windows. Attempting to register a SIGTERM

--- a/puro/lib/src/env/command.dart
+++ b/puro/lib/src/env/command.dart
@@ -69,25 +69,27 @@ Future<int> runFlutterCommand({
 
   final disposeExitSignals = _setupExitSignals(mode);
 
-  if (stdin != null) {
-    unawaited(flutterProcess.stdin.addStream(stdin));
-  }
-  final stdoutFuture = onStdout == null
-      ? null
-      : flutterProcess.stdout.listen(onStdout).asFuture<void>();
-  final stderrFuture = onStderr == null
-      ? null
-      : flutterProcess.stderr.listen(onStderr).asFuture<void>();
-  final exitCode = await flutterProcess.exitCode;
-  await stdoutFuture;
-  await stderrFuture;
+  try {
+    if (stdin != null) {
+      unawaited(flutterProcess.stdin.addStream(stdin));
+    }
+    final stdoutFuture = onStdout == null
+        ? null
+        : flutterProcess.stdout.listen(onStdout).asFuture<void>();
+    final stderrFuture = onStderr == null
+        ? null
+        : flutterProcess.stderr.listen(onStderr).asFuture<void>();
+    final exitCode = await flutterProcess.exitCode;
+    await stdoutFuture;
+    await stderrFuture;
 
-  await disposeExitSignals();
-
-  if (syncCache) {
-    await trySyncFlutterCache(scope: scope, environment: environment);
+    if (syncCache) {
+      await trySyncFlutterCache(scope: scope, environment: environment);
+    }
+    return exitCode;
+  } finally {
+    await disposeExitSignals();
   }
-  return exitCode;
 }
 
 Future<int> runDartCommand({
@@ -142,22 +144,24 @@ Future<int> runDartCommand({
 
   final disposeExitSignals = _setupExitSignals(mode);
 
-  if (stdin != null) {
-    unawaited(dartProcess.stdin.addStream(stdin));
+  try {
+    if (stdin != null) {
+      unawaited(dartProcess.stdin.addStream(stdin));
+    }
+    final stdoutFuture = onStdout == null
+        ? null
+        : dartProcess.stdout.listen(onStdout).asFuture<void>();
+    final stderrFuture = onStderr == null
+        ? null
+        : dartProcess.stderr.listen(onStderr).asFuture<void>();
+    final exitCode = await dartProcess.exitCode;
+    await stdoutFuture;
+    await stderrFuture;
+
+    return exitCode;
+  } finally {
+    await disposeExitSignals();
   }
-  final stdoutFuture = onStdout == null
-      ? null
-      : dartProcess.stdout.listen(onStdout).asFuture<void>();
-  final stderrFuture = onStderr == null
-      ? null
-      : dartProcess.stderr.listen(onStderr).asFuture<void>();
-  final exitCode = await dartProcess.exitCode;
-  await stdoutFuture;
-  await stderrFuture;
-
-  await disposeExitSignals();
-
-  return exitCode;
 }
 
 /// Capture SIGINT and SIGTERM signals. If we don't capture them, the parent


### PR DESCRIPTION
The following simple Dart program doesn't work when run through `puro`, but it does when it runs "unproxied".

```dart
import 'dart:io';

Future<void> main() async {
  print("starting. Current pid = ${pid}");
  print("Press Ctrl+C to exit. It will exit after 3 times.");

  var n = 0;

  ProcessSignal.sigint.watch().listen((signal) {
    print("Caught ${++n} out of 3");

    if (n == 3) {
      print("exiting");
      exit(0);
    }
  });

  await Future.delayed(const Duration(hours: 1));
}
```

This is because when these signals are captured by the `puro` CLI, it terminates. If we don't do nothing on them, the Dart program works as expected.

If the program was listening to sigterm instead, it can be tested by running the following `kill -s SIGTERM <pid>` instead of `Ctrl+C` to send the signal to the dart program. 