### PR TITLE
Fix Bad state: No element error in PuroVersion constructor by using firstWhereOrNull

### DIFF
--- a/puro/CHANGELOG.md
+++ b/puro/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.7
+
+* Bug fixes
+
 ## 1.4.6
 
 * Bug fixes

--- a/puro/lib/src/version.dart
+++ b/puro/lib/src/version.dart
@@ -82,6 +82,9 @@ class PuroVersion {
       final puroPackage = packages
           .cast<Map<String, dynamic>>()
           .firstWhereOrNull((e) => e['name'] == 'puro');
+      if (puroPackage == null && puroPackage?['rootUri'] == null) {
+        return null;
+      }
       final rootUri = Uri.parse(puroPackage?['rootUri'] as String);
       var rootPath = rootUri.toFilePath();
       if (path.isRelative(rootPath)) {

--- a/puro/lib/src/version.dart
+++ b/puro/lib/src/version.dart
@@ -85,7 +85,7 @@ class PuroVersion {
       if (puroPackage == null) {
         return null;
       }
-      final rootUri = Uri.parse(puroPackage?['rootUri'] as String);
+      final rootUri = Uri.parse(puroPackage['rootUri'] as String);
       var rootPath = rootUri.toFilePath();
       if (path.isRelative(rootPath)) {
         path.isRelative(rootPath);

--- a/puro/lib/src/version.dart
+++ b/puro/lib/src/version.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:path/path.dart' as path;
@@ -80,8 +81,8 @@ class PuroVersion {
       final packages = packageData['packages'] as List<dynamic>;
       final puroPackage = packages
           .cast<Map<String, dynamic>>()
-          .firstWhere((e) => e['name'] == 'puro');
-      final rootUri = Uri.parse(puroPackage['rootUri'] as String);
+          .firstWhereOrNull((e) => e['name'] == 'puro');
+      final rootUri = Uri.parse(puroPackage?['rootUri'] as String);
       var rootPath = rootUri.toFilePath();
       if (path.isRelative(rootPath)) {
         path.isRelative(rootPath);

--- a/puro/lib/src/version.dart
+++ b/puro/lib/src/version.dart
@@ -82,7 +82,7 @@ class PuroVersion {
       final puroPackage = packages
           .cast<Map<String, dynamic>>()
           .firstWhereOrNull((e) => e['name'] == 'puro');
-      if (puroPackage == null && puroPackage?['rootUri'] == null) {
+      if (puroPackage == null) {
         return null;
       }
       final rootUri = Uri.parse(puroPackage?['rootUri'] as String);

--- a/puro/pubspec.yaml
+++ b/puro/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puro
 description: A powerful tool for installing and upgrading Flutter versions
-version: 1.4.6
+version: 1.4.7
 repository: https://github.com/pingbird/puro
 homepage: https://puro.dev
 


### PR DESCRIPTION
In the PuroVersion constructor, we were using firstWhere to find the 'puro' package in the packages list. However, if the 'puro' package is not found, firstWhere would throw a Bad state: No element error. To fix this, I've replaced firstWhere with firstWhereOrNull, which returns null if no element matches the predicate.

This change ensures that we don't crash with a Bad state: No element error when the 'puro' package is not found in the packages list.
Let me know if you'd like me to make any changes!
 It should fix #79 & #80 