### PR TITLE
Fix standalone puro using PURO_ROOT over standalone puro root

### DIFF
--- a/puro/lib/src/config.dart
+++ b/puro/lib/src/config.dart
@@ -136,16 +136,39 @@ class PuroConfig {
     resultProjectDir ??= parentProjectDir;
 
     final envPuroRoot = Platform.environment['PURO_ROOT'];
+    log.d('envPuroRoot: $envPuroRoot');
 
-    var puroRootDir = puroRoot != null
-        ? fileSystem.directory(puroRoot)
-        : envPuroRoot?.isNotEmpty ?? false
-            ? fileSystem.directory(envPuroRoot)
-            : fileSystem.directory(homeDir).childDirectory('.puro');
+    final Directory? binPuroRoot = () {
+      final flutterBin = Platform.environment['PURO_FLUTTER_BIN'];
+      if (flutterBin == null) {
+        return null;
+      }
+      final flutterBinDir = fileSystem.directory(flutterBin).absolute;
+      final flutterSdkDir = flutterBinDir.parent;
+      final envDir = flutterSdkDir.parent;
+      final envsDir = envDir.parent;
+      return envsDir.parent;
+    }();
+    log.d('binPuroRoot: $binPuroRoot');
 
+    Directory puroRootDir = () {
+      if (puroRoot != null) {
+        log.d('puroRoot: $puroRoot');
+        return fileSystem.directory(puroRoot);
+      }
+      if (binPuroRoot != null) {
+        return binPuroRoot;
+      }
+      if (envPuroRoot?.isNotEmpty ?? false) {
+        return fileSystem.directory(envPuroRoot);
+      }
+      return fileSystem.directory(homeDir).childDirectory('.puro');
+    }();
+    log.d('puroRootDir: $puroRootDir');
     puroRootDir.createSync(recursive: true);
     puroRootDir =
         fileSystem.directory(puroRootDir.resolveSymbolicLinksSync()).absolute;
+    log.d('puroRootDir (resolved): $puroRootDir');
 
     if (environmentOverride == null) {
       final flutterBin = Platform.environment['PURO_FLUTTER_BIN'];


### PR DESCRIPTION
I have puro installed in standalone mode at
```
/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/
```

When I call the flutter binary of one of the environments (like IntelliJ would call it) it does not use the environment of my standalone version, but instead fallbacks to global ~/.puro/envs/, even when I don't have `PURO_ROOT` set.

I manipulated the flutter file to call puro with log level 4 to better debug the paths
```diff
export PURO_FLUTTER_BIN="$(cd "${PROG_NAME%/*}" ; pwd -P)"
PURO_BIN="$PURO_FLUTTER_BIN/../../../../bin"
-"$PURO_BIN/puro" flutter "$@"
+"$PURO_BIN/puro" --log-level=4 flutter "$@"
```

```
$ /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/flutter --version
...
[V] Flutter SDK: /Users/pascalwelsch/.puro/envs/3.24.1/flutter
...
```

<details>
<summary>Full Output</summary>

```
$ /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/flutter --version
[D] PURO_FLUTTER_BIN: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin
[D] otherPuroRootDir: LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] puroRootDir: LocalDirectory: '/Users/pascalwelsch/.puro'
[V] Started waiting for lock on /Users/pascalwelsch/.puro/prefs.json
[V] Waiting for lock on /Users/pascalwelsch/.puro/prefs.json took 1ms
[D] target: PuroBuildTarget.macosX64
[D] Platform.executable: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/../../../../bin/puro
[D] Platform.resolvedExecutable: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] Platform.script: file:///Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] Platform.packageConfig: null
[D] Using Isolate.packageConfig: file:///Users/pascalwelsch/Projects/myapp/myapp_sidekick/.dart_tool/package_config.json
[W] Error while parsing package configBad state: No element
    #0      ListBase.firstWhere (dart:collection/list.dart:132)
    #1      PuroVersion._getRootFromPackageConfig (package:puro/src/version.dart:83)
    <asynchronous suspension>
    #2      PuroVersion.provider.<anonymous closure> (package:puro/src/version.dart:139)
    <asynchronous suspension>
    #3      checkIfUpdateAvailable (package:puro/src/version.dart:316)
    <asynchronous suspension>
    #4      PuroCommandRunner.runCommand (package:puro/src/command.dart:344)
    <asynchronous suspension>
    #5      main (package:puro/src/cli.dart:256)
    <asynchronous suspension>
    
[D] packageRoot: null
[D] executablePath: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] scriptPath: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] scriptExtension: 
[D] installationType: PuroInstallationType.standalone
[D] version: 1.4.6
[V] Not a distribution, skipping update check
[V] Flutter SDK: /Users/pascalwelsch/.puro/envs/3.24.1/flutter
[V] Started waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/prefs.json
[V] Waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/prefs.json took 0ms
[D] flutterCache.engineVersion: c9b9d5780da342eb3f0f5e439a7db06f7d112575
[D] flutterConfig.engineVersion: c9b9d5780da342eb3f0f5e439a7db06f7d112575
[V] Started waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/update.lock
[V] Waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/update.lock took 0ms
[D] [git 53979] /Users/pascalwelsch/.puro/envs/3.24.1/flutter> git rev-parse HEAD
[D] git: 5874a72aa4c779a02553007c47dacbefba2374dc
[D] [git 53979] finished with exit code 0 in 20ms
[D] flutterCommit: 5874a72aa4c779a02553007c47dacbefba2374dc
[V] Started waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/update.lock
[V] Waiting for lock on /Users/pascalwelsch/.puro/envs/3.24.1/update.lock took 0ms
[V] Setting up flutter tool took 25ms
[D] [git 53982] /Users/pascalwelsch/.puro/envs/3.24.1/flutter> git show HEAD:bin/internal/shared.sh
[D] [git 53982] finished with exit code 0 in 24ms
[D] > sysctl -n hw.optional.arm64
[D] sysctl finished in 30ms
[D] sysctl: 1
    
[D] querying arch of /Users/pascalwelsch/.puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart
[D] > file /Users/pascalwelsch/.puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart
[D] file finished in 18ms
[D] file: /Users/pascalwelsch/.puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable arm64
    
[D] file result: /Users/pascalwelsch/.puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable arm64
    
[D] [arch 53986] > /usr/bin/arch -arch arm64 /Users/pascalwelsch/.puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev --packages=/Users/pascalwelsch/.puro/envs/3.24.1/flutter/packages/flutter_tools/.dart_tool/package_config.json /Users/pascalwelsch/.puro/shared/flutter_tools/5874a72aa4c779a02553007c47dacbefba2374dc/flutter_tools.snapshot --version
Flutter 3.24.1 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 5874a72aa4 (7 weeks ago) • 2024-08-20 16:46:00 -0500
Engine • revision c9b9d5780d
Tools • Dart 3.5.1 • DevTools 2.37.2
[D] [arch 53986] finished with exit code 0 in 610ms
```

</details>

This is surprising, because `PURO_ROOT` is not set, still it uses `/Users/pascalwelsch/.puro` instead of `/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/` where the binary is located.

---

The reason is that if nothing is set and a standalone puro binary is called, it defaults to `fileSystem.directory(homeDir).childDirectory('.puro');`. That is wrong.

Instead it should check `Platform.environment['PURO_FLUTTER_BIN']` and get the path from there.

With the fix in place the path is resolved correctly

```
$ /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/flutter --version
...
[V] Flutter SDK: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter
...
```

<details>
<summary>Full Output</summary>


```
/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/flutter --version
[D] envPuroRoot: /Users/pascalwelsch/.puro
[D] binPuroRoot: LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] puroRootDir: LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] puroRootDir (resolved): LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] PURO_FLUTTER_BIN: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin
[D] otherPuroRootDir: LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] puroRootDir: LocalDirectory: '/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro'
[D] environmentOverride: 3.24.1
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/prefs.json
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/prefs.json took 0ms
[D] target: PuroBuildTarget.macosX64
[D] Platform.executable: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/../../../../bin/puro
[D] Platform.resolvedExecutable: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] Platform.script: file:///Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] Platform.packageConfig: null
[D] Using Isolate.packageConfig: file:///Users/pascalwelsch/Projects/myapp/myapp_sidekick/.dart_tool/package_config.json
[W] Error while parsing package configBad state: No element
    #0      ListBase.firstWhere (dart:collection/list.dart:132)
    #1      PuroVersion._getRootFromPackageConfig (package:puro/src/version.dart:83)
    <asynchronous suspension>
    #2      PuroVersion.provider.<anonymous closure> (package:puro/src/version.dart:139)
    <asynchronous suspension>
    #3      checkIfUpdateAvailable (package:puro/src/version.dart:316)
    <asynchronous suspension>
    #4      PuroCommandRunner.runCommand (package:puro/src/command.dart:344)
    <asynchronous suspension>
    #5      main (package:puro/src/cli.dart:256)
    <asynchronous suspension>
    
[D] packageRoot: null
[D] executablePath: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] scriptPath: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/bin/puro
[D] scriptExtension: 
[D] installationType: PuroInstallationType.distribution
[D] version: 0.0.0-unknown
[V] Checking if update is available
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/latest_version
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/latest_version took 0ms
[D] lastNotification: null
[D] latestVersion: 1.4.6
[D] isOutOfDate: true
[D] willNotify: true
[D] shouldVersionCheck: false
[D] lastVersionCheck: 2024-10-07 22:29:16.833430
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/prefs.json
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/prefs.json took 0ms
[V] Flutter SDK: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/prefs.json
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/prefs.json took 0ms
[D] flutterCache.engineVersion: c9b9d5780da342eb3f0f5e439a7db06f7d112575
[D] flutterConfig.engineVersion: c9b9d5780da342eb3f0f5e439a7db06f7d112575
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/update.lock
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/update.lock took 0ms
[D] [git 55246] /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter> git rev-parse HEAD
[D] git: 5874a72aa4c779a02553007c47dacbefba2374dc
[D] [git 55246] finished with exit code 0 in 7ms
[D] flutterCommit: 5874a72aa4c779a02553007c47dacbefba2374dc
[V] Started waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/update.lock
[V] Waiting for lock on /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/update.lock took 0ms
[V] Setting up flutter tool took 9ms
[D] [git 55247] /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter> git show HEAD:bin/internal/shared.sh
[D] [git 55247] finished with exit code 0 in 10ms
[D] > sysctl -n hw.optional.arm64
[D] sysctl finished in 5ms
[D] sysctl: 1
    
[D] querying arch of /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart
[D] > file /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart
[D] file finished in 5ms
[D] file: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable arm64
    
[D] file result: /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable arm64
    
[D] [arch 55250] > /usr/bin/arch -arch arm64 /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev --packages=/Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/envs/3.24.1/flutter/packages/flutter_tools/.dart_tool/package_config.json /Users/pascalwelsch/Projects/myapp/myapp_sidekick/build/puro/shared/flutter_tools/5874a72aa4c779a02553007c47dacbefba2374dc/flutter_tools.snapshot --version
Flutter 3.24.1 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 5874a72aa4 (7 weeks ago) • 2024-08-20 16:46:00 -0500
Engine • revision c9b9d5780d
Tools • Dart 3.5.1 • DevTools 2.37.2
[D] [arch 55250] finished with exit code 0 in 566ms
```
</details>

Fixes #79 