### PR TITLE
updateEngineVersionFile: don't update the engine if it's tracked in git.

### DIFF
--- a/puro/lib/src/env/create.dart
+++ b/puro/lib/src/env/create.dart
@@ -69,7 +69,6 @@ Future<String?> getEngineVersion({
   required Scope scope,
   required FlutterConfig flutterConfig,
 }) async {
-  
   final git = GitClient.of(scope);
   final result = await git.tryCat(
     repository: flutterConfig.sdkDir,

--- a/puro/lib/src/env/create.dart
+++ b/puro/lib/src/env/create.dart
@@ -47,17 +47,6 @@ Future<void> updateEngineVersionFile({
   }
 
   final git = GitClient.of(scope);
-
-  final result = await git.tryCat(
-    repository: flutterConfig.sdkDir,
-    path: 'bin/internal/engine.version',
-    ref: 'HEAD',
-  );
-  if (result != null) {
-    // We have an actively tracked engine version already, don't upgrade it.
-    return;
-  }
-  
   final remotes = await git.getRemotes(repository: flutterConfig.sdkDir);
 
   final String commit;
@@ -80,7 +69,17 @@ Future<String?> getEngineVersion({
   required Scope scope,
   required FlutterConfig flutterConfig,
 }) async {
-  await updateEngineVersionFile(scope: scope, flutterConfig: flutterConfig);
+  
+  final git = GitClient.of(scope);
+  final result = await git.tryCat(
+    repository: flutterConfig.sdkDir,
+    path: 'bin/internal/engine.version',
+    ref: 'HEAD',
+  );
+  if (result == null) {
+    await updateEngineVersionFile(scope: scope, flutterConfig: flutterConfig);
+  }
+  
   return flutterConfig.engineVersion;
 }
 

--- a/puro/lib/src/env/create.dart
+++ b/puro/lib/src/env/create.dart
@@ -36,6 +36,7 @@ class EnvCreateResult extends CommandResult {
 
 /// Updates the engine version file, to replicate the functionality of
 /// https://github.com/flutter/flutter/blob/master/bin/internal/update_engine_version.sh
+/// See script details at https://github.com/flutter/flutter/issues/163896
 Future<void> updateEngineVersionFile({
   required Scope scope,
   required FlutterConfig flutterConfig,
@@ -46,6 +47,17 @@ Future<void> updateEngineVersionFile({
   }
 
   final git = GitClient.of(scope);
+
+  final result = await git.tryCat(
+    repository: flutterConfig.sdkDir,
+    path: 'bin/internal/engine.version',
+    ref: 'HEAD',
+  );
+  if (result != null) {
+    // We have an actively tracked engine version already, don't upgrade it.
+    return;
+  }
+  
   final remotes = await git.getRemotes(repository: flutterConfig.sdkDir);
 
   final String commit;


### PR DESCRIPTION

Currently, puro downloads a beta version of the Dart SDK for Flutter 3.29.1, the latest stable.

The issue is that this code assumes that the presence of `engine/src/.gn` is sufficient to indicate that the repo needs to download the nearest-to-master SDK version.  
This, however, is insufficient, the actual way to detect if a different engine version should be downloaded is [to check if `bin/internal/engine.version` is tracked by git](https://github.com/flutter/flutter/issues/163896), as, otherwise, Flutter is ALWAYS a monorepo.

Do note that the linked issue is specifically mentioning that this workflow will change.

This, however, is what is done in the shell script shipped with 3.29.1:
https://github.com/flutter/flutter/blob/bfcf486a89adc459e54f2b1e30c2386c034e3dea/bin/internal/update_engine_version.sh#L36-L40
```sh
# On stable, beta, and release tags, the engine.version is tracked by git - do not override it.
TRACKED_ENGINE="$(git -C "$FLUTTER_ROOT" ls-files bin/internal/engine.version)"
if [[ -n "$TRACKED_ENGINE" ]]; then
  exit
fi
```

If the file is tracked in the repository, use the engine commit that's already there, instead of backtracking to the nearest master engine commit.

Fixes #113